### PR TITLE
Allow DB_* fallback for DATABASE_URL and document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
-DB_HOST=
-DB_PORT=
-DB_USER=
-DB_PASSWORD=
-DB_NAME=
-SEED_DATA=
+# PostgreSQL host
+DB_HOST=localhost
+# PostgreSQL port
+DB_PORT=5432
+# Database credentials
+DB_USER=postgres
+DB_PASSWORD=postgres
+# Database name
+DB_NAME=observian
+# Seed initial data on startup (true/false)
+SEED_DATA=false
+# API key for protected endpoints
 API_KEY=
+# Optional: full database URL; overrides DB_* variables above
 DATABASE_URL=

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -16,11 +16,15 @@ DB_PORT = os.getenv("DB_PORT", "5432")
 DB_NAME = os.getenv("DB_NAME")
 DATABASE_URL = os.getenv("DATABASE_URL")
 
-# DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
-
 # SQLAlchemy engine and session setup
 if not DATABASE_URL:
-	raise ValueError("DATABASE_URL environment variable is not set.")
+    if DB_USER and DB_PASSWORD and DB_NAME:
+        DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    else:
+        raise ValueError(
+            "DATABASE_URL environment variable is not set and DB_* variables are incomplete."
+        )
+
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/app/maintenance/prune_old_logs.py
+++ b/app/maintenance/prune_old_logs.py
@@ -9,9 +9,21 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+DB_USER = os.getenv("DB_USER")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_PORT = os.getenv("DB_PORT", "5432")
+DB_NAME = os.getenv("DB_NAME")
 DATABASE_URL = os.getenv("DATABASE_URL")
+
 if not DATABASE_URL:
-    raise ValueError("DATABASE_URL environment variable is not set.")
+    if DB_USER and DB_PASSWORD and DB_NAME:
+        DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    else:
+        raise ValueError(
+            "DATABASE_URL environment variable is not set and DB_* variables are incomplete."
+        )
+
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Summary
- build DATABASE_URL from DB_* variables when not set
- document required environment variables in `.env.example`
- use same DATABASE_URL fallback logic in the prune logs script

## Testing
- `python -m app.db.init_db`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b499181a80832e9fd75a3d7347690e