### PR TITLE
Validate DB host and add startup timeout

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 set -e
 
+# Ensure the database host resolves before attempting connection checks
+if ! getent hosts "$DB_HOST" >/dev/null; then
+  echo "❌ Unable to resolve host: $DB_HOST"
+  exit 1
+fi
+
 echo "🔄 Waiting for PostgreSQL to be ready..."
-while ! nc -z $DB_HOST $DB_PORT; do
+START_TIME=$(date +%s)
+TIMEOUT=${DB_TIMEOUT:-60}
+while ! nc -z "$DB_HOST" "$DB_PORT"; do
+  elapsed=$(( $(date +%s) - START_TIME ))
+  if [ "$elapsed" -ge "$TIMEOUT" ]; then
+    echo "⏰ Timeout: unable to connect to $DB_HOST:$DB_PORT after ${TIMEOUT}s"
+    exit 1
+  fi
   sleep 1
 done
 


### PR DESCRIPTION
## Summary
- ensure database host resolves before waiting for PostgreSQL
- add configurable timeout to abort if database port remains unreachable

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b49046d880832e8eb28895f56c8ed3