### PR TITLE
fix: remove stray character in metrics module

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -1,4 +1,4 @@
-8# app/api/metrics.py
+# app/api/metrics.py
 
 from fastapi import APIRouter, Request, Response
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST


### PR DESCRIPTION
## Summary
- clean up metrics module header

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b499176aa0832ea32a195ae4d4ff49