### PR TITLE
refactor: centralize SQLAlchemy Base

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,8 +1,7 @@
 # app/db/database.py
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker, declarative_base
 import os
 from dotenv import load_dotenv
 

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,9 +1,8 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Float
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 
-Base = declarative_base()
+from app.db.database import Base
 
 class Service(Base):
     __tablename__ = 'services'


### PR DESCRIPTION
## Summary
- centralize SQLAlchemy `Base` in the database module
- reuse shared `Base` in ORM models

## Testing
- `PYTHONPATH=. DATABASE_URL=sqlite:///:memory: pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b499109be8832eb117e051e1de4ff6